### PR TITLE
App should start minimized by default

### DIFF
--- a/VUWare.App/Config/dials-config.json
+++ b/VUWare.App/Config/dials-config.json
@@ -6,7 +6,8 @@
     "globalUpdateIntervalMs": 1000,
     "logFilePath": "",
     "debugMode": false,
-    "serialCommandDelayMs": 150
+    "serialCommandDelayMs": 150,
+    "startMinimized": true
   },
   "dials": [
     {

--- a/VUWare.App/MainWindow.xaml
+++ b/VUWare.App/MainWindow.xaml
@@ -10,7 +10,6 @@
         Width="656"
         ResizeMode="CanMinimize"
         WindowStartupLocation="CenterScreen"
-        WindowState="Minimized"
         Background="Transparent"
         WindowStyle="None"
         AllowsTransparency="True">

--- a/VUWare.App/MainWindow.xaml
+++ b/VUWare.App/MainWindow.xaml
@@ -10,6 +10,7 @@
         Width="656"
         ResizeMode="CanMinimize"
         WindowStartupLocation="CenterScreen"
+        WindowState="Minimized"
         Background="Transparent"
         WindowStyle="None"
         AllowsTransparency="True">

--- a/VUWare.App/MainWindow.xaml.cs
+++ b/VUWare.App/MainWindow.xaml.cs
@@ -64,6 +64,14 @@ namespace VUWare.App
             
             // Then load configuration and start monitoring
             LoadConfiguration();
+            
+            // Apply startMinimized setting from configuration
+            if (_config?.AppSettings.StartMinimized == true)
+            {
+                WindowState = WindowState.Minimized;
+                System.Diagnostics.Debug.WriteLine("[MainWindow] Starting minimized based on configuration");
+            }
+            
             StartInitialization();
         }
 

--- a/VUWare.App/Models/DialConfiguration.cs
+++ b/VUWare.App/Models/DialConfiguration.cs
@@ -220,5 +220,9 @@ namespace VUWare.App.Models
         /// <summary>Delay in milliseconds between firmware detail queries during initialization (default: 50ms)</summary>
         [JsonPropertyName("serialCommandDelayMs")]
         public int SerialCommandDelayMs { get; set; } = 50;
+
+        /// <summary>Start the application minimized to system tray</summary>
+        [JsonPropertyName("startMinimized")]
+        public bool StartMinimized { get; set; } = true;
     }
 }

--- a/VUWare.slnx
+++ b/VUWare.slnx
@@ -3,6 +3,9 @@
     <Platform Name="Any CPU" />
     <Platform Name="x64" />
   </Configurations>
+  <Folder Name="/Solution Items/">
+    <File Path=".github/.copilot-instructions.md" />
+  </Folder>
   <Project Path="VUWare.App/VUWare.App.csproj" Id="b77f28d3-f9a3-47fa-87ae-d677c70b9f37">
     <Platform Solution="*|x64" Project="x64" />
   </Project>


### PR DESCRIPTION
This pull request introduces a new feature to allow the application to start minimized, based on a configurable setting. The main changes include adding the `startMinimized` option to the configuration, updating the settings model, and applying this setting at application startup. Additionally, there is a minor update to the solution file.

**Start Minimized Feature:**

* Added a new `startMinimized` setting (default: true) to the `AppSettings` model in `DialConfiguration.cs`, allowing users to control whether the application starts minimized.
* Updated the configuration file `dials-config.json` to include the new `startMinimized` property.
* Modified `MainWindow.xaml.cs` to check the `startMinimized` setting on startup and minimize the window if enabled.

**Solution Structure:**

* Added a `.github/.copilot-instructions.md` file to the solution items in `VUWare.slnx`.