### PR TITLE
Add First Run Experience

### DIFF
--- a/VUWare.App/App.xaml
+++ b/VUWare.App/App.xaml
@@ -2,9 +2,8 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:VUWare.App"
-             StartupUri="MainWindow.xaml"
              ShutdownMode="OnMainWindowClose">
     <Application.Resources>
-         
+        
     </Application.Resources>
 </Application>

--- a/VUWare.App/App.xaml.cs
+++ b/VUWare.App/App.xaml.cs
@@ -27,6 +27,14 @@ namespace VUWare.App
             
             // Handle Windows shutdown/logoff events
             SessionEnding += App_SessionEnding;
+
+            // Ensure a config file exists (create default if missing)
+            ConfigManager.EnsureDefaultConfigExists();
+
+            // Always start with MainWindow - it handles runInit flag after discovery
+            var mainWindow = new MainWindow();
+            MainWindow = mainWindow;
+            mainWindow.Show();
         }
 
         private void App_SessionEnding(object sender, SessionEndingCancelEventArgs e)
@@ -54,5 +62,4 @@ namespace VUWare.App
             base.OnExit(e);
         }
     }
-
 }

--- a/VUWare.App/Config/dials-config.json
+++ b/VUWare.App/Config/dials-config.json
@@ -8,90 +8,93 @@
     "debugMode": false,
     "serialCommandDelayMs": 150,
     "dialCountOverride": null,
-    "startMinimized": false
+    "startMinimized": false,
+    "runInit": true
   },
   "dials": [
     {
-      "dialUid": "290063000750524834313020",
-      "displayName": "CPU Load",
-      "sensorName": "CPU [#0]: AMD Ryzen 7 9700X",
-      "entryName": "Total CPU Usage",
+      "dialUid": "PLACEHOLDER_DIAL_1",
+      "displayName": "Dial 1",
+      "sensorName": "",
+      "entryName": "",
       "minValue": 0,
       "maxValue": 100,
       "warningThreshold": 80,
       "criticalThreshold": 95,
       "colorConfig": {
-        "colorMode": "static",
-        "staticColor": "Red",
-        "normalColor": "Cyan",
-        "warningColor": "Yellow",
-        "criticalColor": "Red"
-      },
-      "enabled": true,
-      "updateIntervalMs": 500,
-      "displayFormat": "percentage"
-    },
-    {
-      "dialUid": "870056000650564139323920",
-      "displayName": "CPU Temperature",
-      "sensorName": "CPU [#0]: AMD Ryzen 7 9700X: Enhanced",
-      "entryName": "CPU (Tctl/Tdie)",
-      "minValue": 20,
-      "maxValue": 95,
-      "warningThreshold": 75,
-      "criticalThreshold": 88,
-      "colorConfig": {
-        "colorMode": "static",
-        "staticColor": "Green",
+        "colorMode": "off",
+        "staticColor": "Off",
         "normalColor": "Cyan",
         "warningColor": "Yellow",
         "criticalColor": "Red"
       },
       "enabled": true,
       "updateIntervalMs": 1000,
-      "displayFormat": "value",
-      "displayUnit": "°C"
+      "displayFormat": "percentage",
+      "displayUnit": ""
     },
     {
-      "dialUid": "7B006B000650564139323920",
-      "displayName": "GPU Load",
-      "sensorName": "GPU [#0]: AMD Radeon RX 9070: GIGABYTE Radeon RX 9070 GAMING OC 16G (GV-R9070GAMING OC-16GD)",
-      "entryName": "GPU Utilization",
+      "dialUid": "PLACEHOLDER_DIAL_2",
+      "displayName": "Dial 2",
+      "sensorName": "",
+      "entryName": "",
       "minValue": 0,
       "maxValue": 100,
       "warningThreshold": 80,
       "criticalThreshold": 95,
       "colorConfig": {
-        "colorMode": "static",
-        "staticColor": "Cyan",
-        "normalColor": "Cyan",
-        "warningColor": "Blue",
-        "criticalColor": "Purple"
-      },
-      "enabled": true,
-      "updateIntervalMs": 500,
-      "displayFormat": "percentage"
-    },
-    {
-      "dialUid": "31003F000650564139323920",
-      "displayName": "GPU Temperature",
-      "sensorName": "GPU [#0]: AMD Radeon RX 9070: GIGABYTE Radeon RX 9070 GAMING OC 16G (GV-R9070GAMING OC-16GD)",
-      "entryName": "GPU Temperature",
-      "minValue": 20,
-      "maxValue": 110,
-      "warningThreshold": 85,
-      "criticalThreshold": 100,
-      "colorConfig": {
-        "colorMode": "static",
-        "staticColor": "Yellow",
+        "colorMode": "off",
+        "staticColor": "Off",
         "normalColor": "Cyan",
         "warningColor": "Yellow",
         "criticalColor": "Red"
       },
       "enabled": true,
       "updateIntervalMs": 1000,
-      "displayFormat": "value",
-      "displayUnit": "°C"
+      "displayFormat": "percentage",
+      "displayUnit": ""
+    },
+    {
+      "dialUid": "PLACEHOLDER_DIAL_3",
+      "displayName": "Dial 3",
+      "sensorName": "",
+      "entryName": "",
+      "minValue": 0,
+      "maxValue": 100,
+      "warningThreshold": 80,
+      "criticalThreshold": 95,
+      "colorConfig": {
+        "colorMode": "off",
+        "staticColor": "Off",
+        "normalColor": "Cyan",
+        "warningColor": "Yellow",
+        "criticalColor": "Red"
+      },
+      "enabled": true,
+      "updateIntervalMs": 1000,
+      "displayFormat": "percentage",
+      "displayUnit": ""
+    },
+    {
+      "dialUid": "PLACEHOLDER_DIAL_4",
+      "displayName": "Dial 4",
+      "sensorName": "",
+      "entryName": "",
+      "minValue": 0,
+      "maxValue": 100,
+      "warningThreshold": 80,
+      "criticalThreshold": 95,
+      "colorConfig": {
+        "colorMode": "off",
+        "staticColor": "Off",
+        "normalColor": "Cyan",
+        "warningColor": "Yellow",
+        "criticalColor": "Red"
+      },
+      "enabled": true,
+      "updateIntervalMs": 1000,
+      "displayFormat": "percentage",
+      "displayUnit": ""
     }
   ]
 }

--- a/VUWare.App/VUWare.App.csproj
+++ b/VUWare.App/VUWare.App.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>


### PR DESCRIPTION
This pull request implements a robust "first run" and initial setup experience for VUWare, ensuring that new users are guided through configuration when the app is launched for the first time or when no config exists. The changes include auto-creation of a default configuration with placeholder dials, a new `runInit` flag to trigger setup, and updates to the settings window for a guided initial setup. The validation logic is also adjusted to accommodate placeholder dials during setup.

Key changes include:

**First Run Experience & Configuration Initialization**
- Added logic to check for an existing configuration file at startup and create a default one with four placeholder dials if missing. The `runInit` flag is set to `true` to trigger the initial setup experience. (`App.xaml.cs`, `ConfigManager.cs`, `dials-config.json`) [[1]](diffhunk://#diff-486c7b8c7f56e1b1fc7f83de8e439dec0b99b0ea0735300669a10fb405fe5fd4R30-R37) [[2]](diffhunk://#diff-a5e3736190366a9c350d77b6edc4a217cc1f27ea976149e4c621af12efdc74a1L183-R273) [[3]](diffhunk://#diff-8695a8f5d52b5b37a9197310e3d50a840ff60f6a9c0cdb3e41ca01f3865a1c87L11-R97)
- The application now always starts with `MainWindow`, which checks the `runInit` flag and launches the settings window for initial configuration if needed. (`App.xaml`, `App.xaml.cs`) [[1]](diffhunk://#diff-8de93da8574908d83cc9bb744e5766999e82ae931273bf37551b91e31e7f454eL5) [[2]](diffhunk://#diff-486c7b8c7f56e1b1fc7f83de8e439dec0b99b0ea0735300669a10fb405fe5fd4R30-R37)

**Settings Window Enhancements for First Run**
- The `SettingsWindow` now supports a "first-run" mode: it hides Cancel/Apply buttons, displays a welcome message, and prompts for confirmation before exiting to prevent accidental closure during required setup. (`SettingsWindow.xaml.cs`) [[1]](diffhunk://#diff-a85b12bfb5aea5faf606288365d5ad90721e6f307bac14353de4b4fafa4e204dR45-R89) [[2]](diffhunk://#diff-a85b12bfb5aea5faf606288365d5ad90721e6f307bac14353de4b4fafa4e204dR137-R147) [[3]](diffhunk://#diff-a85b12bfb5aea5faf606288365d5ad90721e6f307bac14353de4b4fafa4e204dR289-R305)
- After successful configuration in first-run mode, the `runInit` flag is set to `false` to prevent the setup window from appearing on subsequent launches. (`SettingsWindow.xaml.cs`)

**Configuration & Validation Logic**
- The default configuration (`dials-config.json`) now uses generic placeholder dials with minimal settings, making it easier for users to map their own sensors during setup. (`dials-config.json`, `ConfigManager.cs`) [[1]](diffhunk://#diff-8695a8f5d52b5b37a9197310e3d50a840ff60f6a9c0cdb3e41ca01f3865a1c87L11-R97) [[2]](diffhunk://#diff-a5e3736190366a9c350d77b6edc4a217cc1f27ea976149e4c621af12efdc74a1L183-R273)
- Validation logic in `DialConfiguration` is updated to skip sensor/entry validation for placeholder dials or when in initial setup mode, allowing the user to complete setup without errors. (`DialConfiguration.cs`) [[1]](diffhunk://#diff-c78a1901177a170a503ba20135871ae9869533083474c576860aa3bcc5002437L202-R203) [[2]](diffhunk://#diff-c78a1901177a170a503ba20135871ae9869533083474c576860aa3bcc5002437R230-R252)

**Miscellaneous**
- Minor code and comment cleanups, and support for the new `runInit` property in `AppSettings` and related classes. (`DialConfiguration.cs`, `ConfigManager.cs`) [[1]](diffhunk://#diff-c78a1901177a170a503ba20135871ae9869533083474c576860aa3bcc5002437R315-R321) [[2]](diffhunk://#diff-a5e3736190366a9c350d77b6edc4a217cc1f27ea976149e4c621af12efdc74a1L170-R174)

These changes collectively ensure that new users have a smooth onboarding experience, with clear guidance and robust handling of the initial configuration process.