### PR TITLE
Improve Settings Validation

### DIFF
--- a/VUWare.App/DialConfigurationPanel.xaml
+++ b/VUWare.App/DialConfigurationPanel.xaml
@@ -13,6 +13,16 @@
         <converters:DisplayFormatToVisibilityConverter x:Key="DisplayFormatToVisibilityConverter"/>
         <converters:ColorNameToBrushConverter x:Key="ColorNameToBrushConverter"/>
 
+        <!-- Validation Error Template -->
+        <ControlTemplate x:Key="ValidationErrorTemplate">
+            <StackPanel>
+                <!-- Placeholder for the TextBox itself -->
+                <AdornedElementPlaceholder x:Name="textBox"/>
+                <TextBlock Foreground="#FF6B6B" FontSize="11" Margin="0,2,0,0"
+                           Text="{Binding [0].ErrorContent}" />
+            </StackPanel>
+        </ControlTemplate>
+
         <!-- TextBox Style -->
         <Style TargetType="TextBox">
             <Setter Property="Background" Value="#2a2a2a"/>
@@ -24,6 +34,7 @@
             <Setter Property="HorizontalContentAlignment" Value="Left"/>
             <Setter Property="FontSize" Value="12"/>
             <Setter Property="CaretBrush" Value="#FFFFFF"/>
+            <Setter Property="Validation.ErrorTemplate" Value="{StaticResource ValidationErrorTemplate}"/>
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="TextBox">
@@ -47,6 +58,10 @@
                             <Trigger Property="IsEnabled" Value="False">
                                 <Setter Property="Foreground" Value="#888888"/>
                                 <Setter Property="Background" Value="#1a1a1a"/>
+                            </Trigger>
+                            <Trigger Property="Validation.HasError" Value="True">
+                                <Setter Property="BorderBrush" Value="#FF6B6B"/>
+                                <Setter Property="BorderThickness" Value="2"/>
                             </Trigger>
                         </ControlTemplate.Triggers>
                     </ControlTemplate>
@@ -318,23 +333,24 @@
                 </Grid.RowDefinitions>
 
                 <TextBlock Text="Display Name:" VerticalAlignment="Center" Foreground="#CCCCCC" Grid.Row="0" Grid.Column="0"/>
-                <TextBox Text="{Binding DisplayName, UpdateSourceTrigger=PropertyChanged}" 
+                <TextBox Text="{Binding DisplayName, UpdateSourceTrigger=PropertyChanged, ValidatesOnNotifyDataErrors=True, NotifyOnValidationError=True}" 
                         Height="28" Grid.Row="0" Grid.Column="1" MinWidth="300"
                         ToolTip="Friendly name for this dial (e.g., 'CPU Temperature', 'GPU Load')"/>
 
                 <TextBlock Text="Sensor Name:" VerticalAlignment="Center" Foreground="#CCCCCC" Grid.Row="2" Grid.Column="0"/>
                 <ComboBox ItemsSource="{Binding AvailableSensors}" 
-                         SelectedItem="{Binding SensorName, UpdateSourceTrigger=PropertyChanged}" 
+                         SelectedItem="{Binding SensorName, UpdateSourceTrigger=PropertyChanged, ValidatesOnNotifyDataErrors=True, NotifyOnValidationError=True}" 
                          Height="28" Grid.Row="2" Grid.Column="1" 
                          MinWidth="400" IsTextSearchEnabled="True"
                          ToolTip="Select the HWInfo64 sensor to monitor (e.g., 'CPU [#0]: Intel Core i7-9700K')"/>
 
                 <TextBlock Text="Entry Name:" VerticalAlignment="Center" Foreground="#CCCCCC" Grid.Row="4" Grid.Column="0"/>
                 <ComboBox ItemsSource="{Binding AvailableEntries}" 
-                         SelectedItem="{Binding EntryName, UpdateSourceTrigger=PropertyChanged}"
+                         SelectedItem="{Binding EntryName, UpdateSourceTrigger=PropertyChanged, ValidatesOnNotifyDataErrors=True, NotifyOnValidationError=True}"
                          Height="28" Grid.Row="4" Grid.Column="1" 
                          MinWidth="300" IsTextSearchEnabled="True"
                          ToolTip="Select the specific reading from the sensor (e.g., 'Core Temperature', 'GPU Core Load')"/>
+
             </Grid>
 
             <!-- Display Format Section -->
@@ -451,27 +467,27 @@
                 </Grid.RowDefinitions>
 
                 <TextBlock Text="Min Value:" VerticalAlignment="Center" Foreground="#CCCCCC" Grid.Row="0" Grid.Column="0"/>
-                <TextBox Text="{Binding MinValue, UpdateSourceTrigger=PropertyChanged}" 
+                <TextBox Text="{Binding MinValue, UpdateSourceTrigger=PropertyChanged, ValidatesOnNotifyDataErrors=True, NotifyOnValidationError=True}" 
                         Height="28" Grid.Row="0" Grid.Column="1" Width="150" HorizontalAlignment="Left"
                         ToolTip="Sensor value that maps to 0% on the dial (e.g., 0 for percentage, 20 for temperature)"/>
 
                 <TextBlock Text="Max Value:" VerticalAlignment="Center" Foreground="#CCCCCC" Grid.Row="0" Grid.Column="3"/>
-                <TextBox Text="{Binding MaxValue, UpdateSourceTrigger=PropertyChanged}" 
+                <TextBox Text="{Binding MaxValue, UpdateSourceTrigger=PropertyChanged, ValidatesOnNotifyDataErrors=True, NotifyOnValidationError=True}" 
                         Height="28" Grid.Row="0" Grid.Column="4" Width="150" HorizontalAlignment="Left"
                         ToolTip="Sensor value that maps to 100% on the dial (e.g., 100 for percentage, 90 for temperature)"/>
 
                 <TextBlock Text="Warning Threshold:" VerticalAlignment="Center" Foreground="#CCCCCC" Grid.Row="2" Grid.Column="0"/>
-                <TextBox Text="{Binding WarningThreshold, UpdateSourceTrigger=PropertyChanged}" 
+                <TextBox Text="{Binding WarningThreshold, UpdateSourceTrigger=PropertyChanged, ValidatesOnNotifyDataErrors=True, NotifyOnValidationError=True}" 
                         Height="28" Grid.Row="2" Grid.Column="1" Width="150" HorizontalAlignment="Left"
                         ToolTip="Sensor value above which the warning color is shown (optional)"/>
 
                 <TextBlock Text="Critical Threshold:" VerticalAlignment="Center" Foreground="#CCCCCC" Grid.Row="2" Grid.Column="3"/>
-                <TextBox Text="{Binding CriticalThreshold, UpdateSourceTrigger=PropertyChanged}" 
+                <TextBox Text="{Binding CriticalThreshold, UpdateSourceTrigger=PropertyChanged, ValidatesOnNotifyDataErrors=True, NotifyOnValidationError=True}" 
                         Height="28" Grid.Row="2" Grid.Column="4" Width="150" HorizontalAlignment="Left"
                         ToolTip="Sensor value above which the critical color is shown (optional, must be > warning threshold)"/>
 
                 <TextBlock Text="Update Interval (ms):" VerticalAlignment="Center" Foreground="#CCCCCC" Grid.Row="4" Grid.Column="0"/>
-                <TextBox Text="{Binding UpdateIntervalMs, UpdateSourceTrigger=PropertyChanged}" 
+                <TextBox Text="{Binding UpdateIntervalMs, UpdateSourceTrigger=PropertyChanged, ValidatesOnNotifyDataErrors=True, NotifyOnValidationError=True}" 
                         Height="28" Grid.Row="4" Grid.Column="1" Width="150" HorizontalAlignment="Left" TextChanged="TextBox_TextChanged"
                         ToolTip="How often to update this dial in milliseconds (min: 100ms, recommended: 500-1000ms)"/>
             </Grid>

--- a/VUWare.App/SettingsWindow.xaml
+++ b/VUWare.App/SettingsWindow.xaml
@@ -19,6 +19,16 @@
     <Window.Resources>
         <converters:ColorModeToVisibilityConverter x:Key="ColorModeToVisibilityConverter"/>
         
+        <!-- Validation Error Template -->
+        <ControlTemplate x:Key="ValidationErrorTemplate">
+            <StackPanel>
+                <!-- Placeholder for the control itself -->
+                <AdornedElementPlaceholder x:Name="controlPlaceholder"/>
+                <TextBlock Foreground="#FF6B6B" FontSize="11" Margin="0,2,0,0"
+                           Text="{Binding [0].ErrorContent}" />
+            </StackPanel>
+        </ControlTemplate>
+        
         <!-- Modern Flat Button Style -->
         <Style x:Key="ModernButton" TargetType="Button">
             <Setter Property="Background" Value="#0078d4"/>

--- a/VUWare.App/SettingsWindow.xaml.cs
+++ b/VUWare.App/SettingsWindow.xaml.cs
@@ -213,6 +213,17 @@ namespace VUWare.App
         /// </summary>
         private async void ApplyButton_Click(object sender, RoutedEventArgs e)
         {
+            // Check for validation errors before applying
+            if (HasValidationErrors())
+            {
+                MessageBox.Show(
+                    "Please correct all validation errors before applying changes.",
+                    "Validation Errors",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Warning);
+                return;
+            }
+
             try
             {
                 ApplyChanges();
@@ -238,6 +249,17 @@ namespace VUWare.App
         /// </summary>
         private async void OKButton_Click(object sender, RoutedEventArgs e)
         {
+            // Check for validation errors before saving
+            if (HasValidationErrors())
+            {
+                MessageBox.Show(
+                    "Please correct all validation errors before saving.",
+                    "Validation Errors",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Warning);
+                return;
+            }
+
             try
             {
                 ApplyChanges();
@@ -273,6 +295,32 @@ namespace VUWare.App
         }
 
         /// <summary>
+        /// Checks if there are any validation errors in the settings or dial configurations.
+        /// </summary>
+        /// <returns>True if there are validation errors, false otherwise</returns>
+        private bool HasValidationErrors()
+        {
+            // Check settings view model
+            if (_settingsViewModel != null && _settingsViewModel.HasErrors)
+            {
+                System.Diagnostics.Debug.WriteLine("[SettingsWindow] Validation errors found in settings");
+                return true;
+            }
+
+            // Check all dial view models
+            foreach (var dialViewModel in _dialViewModels)
+            {
+                if (dialViewModel.HasErrors)
+                {
+                    System.Diagnostics.Debug.WriteLine($"[SettingsWindow] Validation errors found in Dial #{dialViewModel.DialNumber}");
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Cancels any changes and closes the dialog.
         /// </summary>
         private void CancelButton_Click(object sender, RoutedEventArgs e)
@@ -303,6 +351,7 @@ namespace VUWare.App
                 return;
             }
             
+            // Normal mode - just close without saving
             DialogResult = false;
             Close();
         }

--- a/VUWare.App/SettingsWindow.xaml.cs
+++ b/VUWare.App/SettingsWindow.xaml.cs
@@ -158,6 +158,9 @@ namespace VUWare.App
             {
                 generalSettingsBorder.DataContext = _settingsViewModel;
             }
+
+            // Subscribe to validation error changes for settings
+            _settingsViewModel.ErrorsChanged += OnValidationErrorsChanged;
         }
 
         /// <summary>
@@ -183,6 +186,9 @@ namespace VUWare.App
                 var viewModel = new DialConfigurationViewModel(dialConfig, dialNumber);
                 _dialViewModels.Add(viewModel);
 
+                // Subscribe to validation error changes
+                viewModel.ErrorsChanged += OnValidationErrorsChanged;
+
                 // Load sensor data if HWInfo is available
                 if (_hwInfoController != null && _hwInfoController.IsConnected)
                 {
@@ -206,6 +212,36 @@ namespace VUWare.App
             }
             
             System.Diagnostics.Debug.WriteLine($"[SettingsWindow] Created {_dialViewModels.Count} dial configuration panels");
+
+            // Update button states after initialization
+            UpdateButtonStates();
+        }
+
+        /// <summary>
+        /// Handles validation error changes from any view model.
+        /// </summary>
+        private void OnValidationErrorsChanged(object? sender, System.ComponentModel.DataErrorsChangedEventArgs e)
+        {
+            // Update button states on the UI thread
+            Dispatcher.Invoke(UpdateButtonStates);
+        }
+
+        /// <summary>
+        /// Updates the enabled state of OK and Apply buttons based on validation status.
+        /// </summary>
+        private void UpdateButtonStates()
+        {
+            bool hasErrors = HasValidationErrors();
+            
+            if (OKButton != null)
+            {
+                OKButton.IsEnabled = !hasErrors;
+            }
+            
+            if (ApplyButton != null)
+            {
+                ApplyButton.IsEnabled = !hasErrors;
+            }
         }
 
         /// <summary>
@@ -213,14 +249,9 @@ namespace VUWare.App
         /// </summary>
         private async void ApplyButton_Click(object sender, RoutedEventArgs e)
         {
-            // Check for validation errors before applying
+            // Button should be disabled if there are errors, but double-check
             if (HasValidationErrors())
             {
-                MessageBox.Show(
-                    "Please correct all validation errors before applying changes.",
-                    "Validation Errors",
-                    MessageBoxButton.OK,
-                    MessageBoxImage.Warning);
                 return;
             }
 
@@ -249,14 +280,9 @@ namespace VUWare.App
         /// </summary>
         private async void OKButton_Click(object sender, RoutedEventArgs e)
         {
-            // Check for validation errors before saving
+            // Button should be disabled if there are errors, but double-check
             if (HasValidationErrors())
             {
-                MessageBox.Show(
-                    "Please correct all validation errors before saving.",
-                    "Validation Errors",
-                    MessageBoxButton.OK,
-                    MessageBoxImage.Warning);
                 return;
             }
 


### PR DESCRIPTION
This pull request introduces comprehensive validation support for user input in the dial configuration and settings panels. The main improvements include implementing property-level validation in the `DialConfigurationViewModel`, updating the UI to display validation errors, and disabling the OK/Apply buttons when invalid input is detected. These changes enhance user experience by providing immediate feedback and preventing invalid configurations from being saved.

**Validation Infrastructure and ViewModel Enhancements:**

* Implemented the `INotifyDataErrorInfo` interface in `DialConfigurationViewModel`, including storage and notification of validation errors, and added validation logic for all user-editable properties (e.g., `DisplayName`, `SensorName`, `EntryName`, `MinValue`, `MaxValue`, `WarningThreshold`, `CriticalThreshold`, `UpdateIntervalMs`). Each property setter now triggers validation, and error messages are managed per property. [[1]](diffhunk://#diff-60c92dc596d549f53916d35892d35146f7f1166997c45f9b4d6670a4c14c1460R7-R16) [[2]](diffhunk://#diff-60c92dc596d549f53916d35892d35146f7f1166997c45f9b4d6670a4c14c1460R44-R62) [[3]](diffhunk://#diff-60c92dc596d549f53916d35892d35146f7f1166997c45f9b4d6670a4c14c1460R74-R136) [[4]](diffhunk://#diff-60c92dc596d549f53916d35892d35146f7f1166997c45f9b4d6670a4c14c1460L129-R178) [[5]](diffhunk://#diff-60c92dc596d549f53916d35892d35146f7f1166997c45f9b4d6670a4c14c1460R221-R335)

**UI/UX Improvements for Validation:**

* Added a reusable `ValidationErrorTemplate` in both `DialConfigurationPanel.xaml` and `SettingsWindow.xaml` to visually display validation errors beneath input controls. [[1]](diffhunk://#diff-da57a8ea8c8a6396ee2af274847446197cd3635bc7cf14b7287dc6852a5f3033R16-R25) [[2]](diffhunk://#diff-571a8dac10a8941e8227f72da8660960bf7edb3feba4a5a51459add02d678b31R22-R31)
* Updated `TextBox` and `ComboBox` bindings to enable validation error reporting (`ValidatesOnNotifyDataErrors=True`, `NotifyOnValidationError=True`) and styled controls to highlight errors (e.g., red border when invalid). [[1]](diffhunk://#diff-da57a8ea8c8a6396ee2af274847446197cd3635bc7cf14b7287dc6852a5f3033R37) [[2]](diffhunk://#diff-da57a8ea8c8a6396ee2af274847446197cd3635bc7cf14b7287dc6852a5f3033R62-R65) [[3]](diffhunk://#diff-da57a8ea8c8a6396ee2af274847446197cd3635bc7cf14b7287dc6852a5f3033L321-R353) [[4]](diffhunk://#diff-da57a8ea8c8a6396ee2af274847446197cd3635bc7cf14b7287dc6852a5f3033L454-R490)

**Settings Window Logic and Button State Management:**

* Subscribed to `ErrorsChanged` events from both the settings and dial configuration view models in `SettingsWindow.xaml.cs`, and added logic to enable or disable the OK/Apply buttons based on validation status. [[1]](diffhunk://#diff-a85b12bfb5aea5faf606288365d5ad90721e6f307bac14353de4b4fafa4e204dR161-R163) [[2]](diffhunk://#diff-a85b12bfb5aea5faf606288365d5ad90721e6f307bac14353de4b4fafa4e204dR189-R191) [[3]](diffhunk://#diff-a85b12bfb5aea5faf606288365d5ad90721e6f307bac14353de4b4fafa4e204dR215-R257)
* Added a method to check for validation errors across all view models and prevent the OK/Apply actions if errors are present, ensuring invalid data cannot be saved. [[1]](diffhunk://#diff-a85b12bfb5aea5faf606288365d5ad90721e6f307bac14353de4b4fafa4e204dR283-R288) [[2]](diffhunk://#diff-a85b12bfb5aea5faf606288365d5ad90721e6f307bac14353de4b4fafa4e204dR323-R348)

These changes collectively provide robust user input validation, immediate feedback, and prevent misconfiguration in the application's settings.