### PR TITLE
Add Installer/README.md to Solution Items in VUWare.slnx

### DIFF
--- a/VUWare.slnx
+++ b/VUWare.slnx
@@ -5,6 +5,7 @@
   </Configurations>
   <Folder Name="/Solution Items/">
     <File Path=".github/.copilot-instructions.md" />
+    <File Path="Installer/README.md" />
   </Folder>
   <Project Path="VUWare.App/VUWare.App.csproj" Id="b77f28d3-f9a3-47fa-87ae-d677c70b9f37">
     <Platform Solution="*|x64" Project="x64" />


### PR DESCRIPTION
Included Installer/README.md as a solution-level item in the VUWare.slnx file, making it accessible from within the solution for easier reference and documentation access.